### PR TITLE
Fix gcloud infinite loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ HELM ?= helm
 
 REGISTRY_IMAGE="codenotary/kube-notary:latest"
 TEST_FLAGS ?= -v -race
+TAGS ?= -tags disable_aws -tags disable_gcp -tags disable_azure
 
 export GO111MODULE=on
 
@@ -16,14 +17,14 @@ help: ## Show this help.
 .PHONY: kube-notary
 kube-notary: ## Build kube-notary binary
 	$(GO) get github.com/rakyll/statik
-	GOOS=linux GOARCH=amd64 $(GO) generate ./pkg/status
-	GOOS=linux GOARCH=amd64 $(GO) build ./cmd/kube-notary
+	GOOS=linux GOARCH=amd64 $(GO) generate ./pkg/status 
+	GOOS=linux GOARCH=amd64 $(GO) build $(TAGS) ./cmd/kube-notary
 
 .PHONY: kube-notary/debug
 kube-notary/debug: ## Build kube-notary not optimized binary (-gcflags='all=-N -l)
 	$(GO) get github.com/rakyll/statik
-	GOOS=linux GOARCH=amd64 $(GO) generate ./pkg/status
-	GOOS=linux GOARCH=amd64 $(GO) build -gcflags "all=-N -l" ./cmd/kube-notary
+	GOOS=linux GOARCH=amd64 $(GO) generate ./pkg/status $(TAGS)
+	GOOS=linux GOARCH=amd64 $(GO) build $(TAGS) -gcflags "all=-N -l" ./cmd/kube-notary
 
 .PHONY: image
 image: ## Build kube-notary image
@@ -54,7 +55,7 @@ CHANGELOG.md: ## Update changelog
 .PHONY: test
 test: ## Launch kube-notary GO tests
 	$(GO) vet ./...
-	$(GO) test ${TEST_FLAGS} ./...
+	$(GO) test $(TAGS) ${TEST_FLAGS} ./...
 
 .PHONY: test/e2e.local
 test/e2e.local: ## Launch kube-notary local tests


### PR DESCRIPTION
Disabling credentials helper that are not meant to be used *inside* a pod running on the cloud